### PR TITLE
policy_5 exports all policies and save it in folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,42 @@ complianceStandardName = "<COMPLIANCE_STANDARD_NAME>"
 Initialize Terraform: Run `terraform init` to initialize the provider.
 Apply Configuration: Run `terraform apply` to create the resources.
 
+# Code Explanation
+
+- **policy_5**
+
+This data source fetches all policies from Prisma Cloud.
+
+```hcl
+data "prismacloud_policies" "all_policies" {}
+```
+This resource creates a local file for each policy. The file is named based on the policy type and whether it is a built-in or custom policy. The content of the file is the JSON-encoded policy data.
+```hcl
+resource "local_file" "exported_policy_files" {
+  for_each = {
+    for key, value in data.prismacloud_policies.all_policies.listing :
+    key => value
+  }
+  filename = "policies/${each.value.policy_type}/${each.value.system_default ? "builtin" : "custom"}/${substr(each.value.name, 0, 60)}.json"
+  content  = jsonencode(each.value)
+}
+```
+The exported policies will be organized in the following directory structure:
+
+```
+policies/
+  ├── <policy_type>/
+  │   ├── builtin/
+  │   │   ├── <policy_name>.json
+  │   └── custom/
+  │       ├── <policy_name>.json
+```
+- <policy_type>: The type of the policy (e.g., network, config).
+- builtin: Built-in policies provided by Prisma Cloud.
+- custom: Custom policies created by the user.
+- <policy_name>: The name of the policy, truncated to 60 characters.
+
+
 # Contributions
 
 Contributions to this repository are welcome. Please fork the repository and create a pull request with your changes.

--- a/policy_5.tf
+++ b/policy_5.tf
@@ -1,0 +1,12 @@
+data "prismacloud_policies" "all_policies" {}
+
+resource "local_file" "exported_policy_files" {
+  #  for_each = data.prismacloud_policies.all_policies.listing
+  for_each = {
+    for key, value in data.prismacloud_policies.all_policies.listing :
+    key => value
+  }
+  # Determine the folder based on policy type and owner
+  filename = "policies/${each.value.policy_type}/${each.value.system_default ? "builtin" : "custom"}/${substr(each.value.name, 0, 60)}.json"
+  content  = jsonencode(each.value)
+}


### PR DESCRIPTION
policy_5 exports all Prisma Cloud policies to local JSON files. This code organizes policies based on their type and whether they are built-in or custom, making it easier to manage and review them